### PR TITLE
configure.ac: Set BEBA_STATE_FLUSH_INTERVAL to 0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,7 +81,7 @@ AC_DEFINE(BEBA_CTRL_PLANE_RELAX,    0,  [BEBA control-plane relax factor (power 
 AC_DEFINE(BEBA_MATCH_POOL_SIZE,     16,  [BEBA size of pool for small TLV node])
 AC_DEFINE(BEBA_MATCH_VALUE_SIZE,    16,  [BEBA size of TLV value])
 AC_DEFINE(BEBA_HMAP_INIT_SIZE,      8,   [BEBA size of init hmap])
-AC_DEFINE(BEBA_STATE_FLUSH_INTERVAL,60,  [BEBA state table flush interval (in seconds)])
+AC_DEFINE(BEBA_STATE_FLUSH_INTERVAL,0,  [BEBA state table flush interval (in seconds)])
 
 
 #OFP_CHECK_LINUX(l26, 2.6, KBLD26, KSRC26, L26_ENABLED)


### PR DESCRIPTION
When set to 60, rules are removed from the controller realy slowly. This
is not good for applications that create and remove states frequently.