### PR TITLE
State table flush fix

### DIFF
--- a/oflib-exp/ofl-exp-beba.h
+++ b/oflib-exp/ofl-exp-beba.h
@@ -270,7 +270,7 @@ bool
 extractors_are_equal(struct key_extractor *ke1, struct key_extractor *ke2);
 
 void
-state_table_flush(struct state_table *table);
+state_table_flush(struct state_table *table, uint64_t now_us);
 
 /*
  * State Sync: One extra argument (i.e., ntf_message) is passed at the end of this function.

--- a/udatapath/datapath.c
+++ b/udatapath/datapath.c
@@ -296,7 +296,7 @@ dp_run(struct datapath *dp, int nrun) {
 
     if (now >= dp->next_state_table_flush){
         dp->next_state_table_flush = now + BEBA_STATE_FLUSH_INTERVAL;
-        pipeline_flush_state_tables(dp->pipeline);
+        pipeline_flush_state_tables(dp->pipeline, now*1000000);
     }
 
     poll_set_timer_wait(100);

--- a/udatapath/pipeline.c
+++ b/udatapath/pipeline.c
@@ -667,12 +667,12 @@ pipeline_timeout(struct pipeline *pl) {
 }
 
 void
-pipeline_flush_state_tables(struct pipeline *pl) {
+pipeline_flush_state_tables(struct pipeline *pl, uint64_t now_us) {
     int i;
 
     for (i = 0; i < PIPELINE_TABLES; i++) {
         if (state_table_is_enabled(pl->tables[i]->state_table)) {
-            state_table_flush(pl->tables[i]->state_table);
+            state_table_flush(pl->tables[i]->state_table, now_us);
         }
     }
 }

--- a/udatapath/pipeline.h
+++ b/udatapath/pipeline.h
@@ -104,7 +104,7 @@ pipeline_timeout(struct pipeline *pl);
 
 /* Commands pipeline to check if any state entry in any state table is timed out. */
 void
-pipeline_flush_state_tables(struct pipeline *pl);
+pipeline_flush_state_tables(struct pipeline *pl, uint64_t now_us);
 
 /* Detroys the pipeline. */
 void


### PR DESCRIPTION
-state table flush fix
-soft timeout are applied every BEBA_STATE_FLUSH_INTERVAL seconds
-timestamp variables renaming for the sake of clarity