### PR TITLE
Update netdev.c

### DIFF
--- a/lib/netdev.c
+++ b/lib/netdev.c
@@ -485,7 +485,7 @@ netdev_setup_slicing(struct netdev *netdev, uint16_t num_queues)
     /* remove any previous queue configuration for this device */
     error = do_remove_qdisc(netdev->name);
     if (error) {
-        return error;
+	// return error; No need to return error as there may not exist any previous configuration
     }
 
     /* Configure tc queue discipline to allow slicing queues */


### PR DESCRIPTION
ofdatapath throwing error if not run with --no-slicing option when run using mininet