### PR TITLE
dpctl queue-get-config showing only 1 queue

### DIFF
--- a/oflib/ofl-messages-unpack.c
+++ b/oflib/ofl-messages-unpack.c
@@ -1591,6 +1591,7 @@ ofl_msg_unpack_queue_get_config_reply(struct ofp_header const *src, size_t *len,
     struct ofp_packet_queue *queue;
     ofl_err error;
     size_t i;
+    size_t len1=0,len2=0;
 
     if (*len < sizeof(struct ofp_queue_get_config_reply)) {
         OFL_LOG_WARN(LOG_MODULE, "Received GET_CONFIG_REPLY has invalid length (%zu).", *len);
@@ -1612,6 +1613,10 @@ ofl_msg_unpack_queue_get_config_reply(struct ofp_header const *src, size_t *len,
 
     queue = sr->queues;
     for (i = 0; i < dr->queues_num; i++) {
+	/* This is so that it can parse packet with more than 1 queue. 
+	*   Previously, dpctl was showing only 1 queue even if more than 1 queues are configured. */
+	len1=*len-(sizeof(struct ofp_packet_queue)+sizeof(struct ofp_queue_prop_min_rate))*((int)dr->queues_num-1-i);
+	len2=*len-(sizeof(struct ofp_packet_queue)+sizeof(struct ofp_queue_prop_min_rate))*((int)dr->queues_num-1-i);
         error = ofl_structs_packet_queue_unpack(queue, len, &(dr->queues[i]));
         if (error) {
             OFL_UTILS_FREE_ARR_FUN(dr->queues, i,
@@ -1619,6 +1624,7 @@ ofl_msg_unpack_queue_get_config_reply(struct ofp_header const *src, size_t *len,
             free (dr);
             return error;
         }
+	*len-=len2-len1; //This is so that it can parse packet with more than 1 queue. 
         queue = (struct ofp_packet_queue *)((uint8_t *)queue + ntohs(queue->len));
     }
 

--- a/oflib/ofl-messages-unpack.c
+++ b/oflib/ofl-messages-unpack.c
@@ -1617,7 +1617,7 @@ ofl_msg_unpack_queue_get_config_reply(struct ofp_header const *src, size_t *len,
 	*   Previously, dpctl was showing only 1 queue even if more than 1 queues are configured. */
 	len1=*len-(sizeof(struct ofp_packet_queue)+sizeof(struct ofp_queue_prop_min_rate))*((int)dr->queues_num-1-i);
 	len2=*len-(sizeof(struct ofp_packet_queue)+sizeof(struct ofp_queue_prop_min_rate))*((int)dr->queues_num-1-i);
-        error = ofl_structs_packet_queue_unpack(queue, len, &(dr->queues[i]));
+        error = ofl_structs_packet_queue_unpack(queue, &len1, &(dr->queues[i]));
         if (error) {
             OFL_UTILS_FREE_ARR_FUN(dr->queues, i,
                                    ofl_structs_free_packet_queue);


### PR DESCRIPTION
Even if multiple queues are configured, dpctl shows only 1 queue. The proposed change will work as long as structure size of ofp_queue_prop_min_rate, ofp_queue_prop_max_rate and ofp_queue_prop_experimenter remains same.

Also, I am working on patch after which dpctl will support max-rate setting also. Currently it supports min-rate settings only.