### PR TITLE
fix OpenDaylight handshake

### DIFF
--- a/lib/vconn.c
+++ b/lib/vconn.c
@@ -382,7 +382,7 @@ vcs_recv_hello(struct vconn *vconn)
         struct ofp_header *oh = b->data;
 
         if (oh->type == OFPT_HELLO) {
-            if (b->size > sizeof *oh) {
+            if (b->size > 4*sizeof *oh) {
                 struct ds msg = DS_EMPTY_INITIALIZER;
                 ds_put_format(&msg, "%s: extra-long hello:\n", vconn->name);
                 ds_put_hex_dump(&msg, b->data, b->size, 0, true);

--- a/udatapath/datapath.c
+++ b/udatapath/datapath.c
@@ -715,9 +715,9 @@ dp_handle_set_desc(struct datapath *dp, struct ofl_exp_openflow_msg_set_dp_desc 
 }
 
 static ofl_err
-dp_check_generation_id(struct datapath *dp, uint64_t new_gen_id)
-{
-    if(new_gen_id < dp->generation_id) {
+dp_check_generation_id(struct datapath *dp, uint64_t new_gen_id){
+
+    if(dp->generation_id >= 0  && ((int64_t)(new_gen_id - dp->generation_id) < 0) ){        
         return ofl_error(OFPET_ROLE_REQUEST_FAILED, OFPRRFC_STALE);
     }
     else dp->generation_id = new_gen_id;


### PR DESCRIPTION
A quick fix to avoid handshake establishments errors with OpenDaylight controller. 
Tested with 3 beba-switches in a  mininet topology and OpenDaylight boron-sr1.